### PR TITLE
Add ESP8266 AT command driver for STM32F429

### DIFF
--- a/alarm/HARDWARE/ESP8266/esp8266.c
+++ b/alarm/HARDWARE/ESP8266/esp8266.c
@@ -1,0 +1,116 @@
+#include "esp8266.h"
+#include "delay.h"
+#include <string.h>
+#include <stdio.h>
+#include "stm32f4xx_hal.h"
+
+UART_HandleTypeDef ESP8266_UART_Handler;    //USART3
+
+#if EN_USART3_RX
+u8 ESP8266_RX_BUF[512];
+u16 ESP8266_RX_CNT=0;
+
+void USART3_IRQHandler(void)
+{
+    u8 res;
+    if((__HAL_UART_GET_FLAG(&ESP8266_UART_Handler,UART_FLAG_RXNE)!=RESET))
+    {
+        HAL_UART_Receive(&ESP8266_UART_Handler,&res,1,1000);
+        if(ESP8266_RX_CNT<sizeof(ESP8266_RX_BUF))
+        {
+            ESP8266_RX_BUF[ESP8266_RX_CNT]=res;
+            ESP8266_RX_CNT++;
+        }
+    }
+}
+#endif
+
+static void ESP8266_Clear(void)
+{
+    ESP8266_RX_CNT=0;
+    memset(ESP8266_RX_BUF,0,sizeof(ESP8266_RX_BUF));
+}
+
+//USART3初始化
+void ESP8266_Init(u32 bound)
+{
+    GPIO_InitTypeDef GPIO_Initure;
+
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_USART3_CLK_ENABLE();
+
+    GPIO_Initure.Pin=GPIO_PIN_10|GPIO_PIN_11;    //PC10 PC11
+    GPIO_Initure.Mode=GPIO_MODE_AF_PP;
+    GPIO_Initure.Pull=GPIO_PULLUP;
+    GPIO_Initure.Speed=GPIO_SPEED_HIGH;
+    GPIO_Initure.Alternate=GPIO_AF7_USART3;
+    HAL_GPIO_Init(GPIOC,&GPIO_Initure);
+
+    ESP8266_UART_Handler.Instance=USART3;
+    ESP8266_UART_Handler.Init.BaudRate=bound;
+    ESP8266_UART_Handler.Init.WordLength=UART_WORDLENGTH_8B;
+    ESP8266_UART_Handler.Init.StopBits=UART_STOPBITS_1;
+    ESP8266_UART_Handler.Init.Parity=UART_PARITY_NONE;
+    ESP8266_UART_Handler.Init.HwFlowCtl=UART_HWCONTROL_NONE;
+    ESP8266_UART_Handler.Init.Mode=UART_MODE_TX_RX;
+    HAL_UART_Init(&ESP8266_UART_Handler);
+
+    __HAL_UART_DISABLE_IT(&ESP8266_UART_Handler,UART_IT_TC);
+#if EN_USART3_RX
+    __HAL_UART_ENABLE_IT(&ESP8266_UART_Handler,UART_IT_RXNE);
+    HAL_NVIC_EnableIRQ(USART3_IRQn);
+    HAL_NVIC_SetPriority(USART3_IRQn,3,3);
+#endif
+}
+
+u8 ESP8266_SendCmd(char *cmd,char *ack,u16 waittime)
+{
+    u8 res=0;
+    ESP8266_Clear();
+    HAL_UART_Transmit(&ESP8266_UART_Handler,(u8*)cmd,strlen(cmd),1000);
+    while(waittime--)
+    {
+        delay_ms(1);
+        if(ack && strstr((char*)ESP8266_RX_BUF,ack))
+        {
+            res=0;break;
+        }
+    }
+    if(waittime==0)res=1;
+    return res;
+}
+
+u8 ESP8266_JoinAP(char *ssid,char *pwd)
+{
+    char cmd[120];
+    sprintf(cmd,"AT+CWJAP=\"%s\",\"%s\"\r\n",ssid,pwd);
+    return ESP8266_SendCmd(cmd,"WIFI GOT IP",5000);
+}
+
+u8 ESP8266_StartTCP(char *ip,char *port)
+{
+    char cmd[60];
+    sprintf(cmd,"AT+CIPSTART=\"TCP\",\"%s\",%s\r\n",ip,port);
+    return ESP8266_SendCmd(cmd,"CONNECT",4000);
+}
+
+u8 ESP8266_SendData(char *data)
+{
+    char cmd[32];
+    sprintf(cmd,"AT+CIPSEND=%d\r\n",strlen(data));
+    if(ESP8266_SendCmd(cmd,">",2000))return 1;
+    return ESP8266_SendCmd(data,"SEND OK",4000);
+}
+
+void ESP8266_Receive_Data(u8 *buf,u16 *len)
+{
+    u16 rxlen=ESP8266_RX_CNT;
+    *len=0;
+    delay_ms(10);
+    if(rxlen==ESP8266_RX_CNT && rxlen)
+    {
+        memcpy(buf,ESP8266_RX_BUF,rxlen);
+        *len=rxlen;
+        ESP8266_RX_CNT=0;
+    }
+}

--- a/alarm/HARDWARE/ESP8266/esp8266.h
+++ b/alarm/HARDWARE/ESP8266/esp8266.h
@@ -1,0 +1,24 @@
+#ifndef __ESP8266_H
+#define __ESP8266_H
+#include "sys.h"
+//////////////////////////////////////////////////////////////////////////////////
+// 本程序只供学习使用，未经作者许可，不得用于其它任何用途
+// ALIENTEK STM32F429
+// ESP8266 AT指令驱动
+// 版权所有，盗版必究
+////////////////////////////////////////////////////////////////////////////////// 
+
+#define EN_USART3_RX    1           //1,使能USART3接收;0,禁止
+
+extern UART_HandleTypeDef ESP8266_UART_Handler;
+extern u8  ESP8266_RX_BUF[512];
+extern u16 ESP8266_RX_CNT;
+
+void ESP8266_Init(u32 bound);
+u8 ESP8266_SendCmd(char *cmd,char *ack,u16 waittime);
+u8 ESP8266_JoinAP(char *ssid,char *pwd);
+u8 ESP8266_StartTCP(char *ip,char *port);
+u8 ESP8266_SendData(char *data);
+void ESP8266_Receive_Data(u8 *buf,u16 *len);
+
+#endif


### PR DESCRIPTION
## Summary
- add ESP8266 AT command driver using USART3 for STM32F429
- support WiFi join, TCP connection and data send/receive helpers

## Testing
- `gcc -c alarm/HARDWARE/ESP8266/esp8266.c -Ialarm/HARDWARE/ESP8266 -Ialarm/SYSTEM/sys -Ialarm/HALLIB/STM32F4xx_HAL_Driver/Inc -Ialarm/USER -Ialarm/CORE -DUSE_HAL_DRIVER -DSTM32F429xx` *(fails: cmsis_gcc.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac204e43d08326981c8fa359cef77d